### PR TITLE
(Fix_39) Inconsistency Between LightFTP and RFC 959: Violation of state transition between USER and PASS commands.

### DIFF
--- a/src/ftpserv.c
+++ b/src/ftpserv.c
@@ -327,7 +327,10 @@ int ftpNOOP(PFTPCONTEXT context, const char *params)
 int ftpPWD(PFTPCONTEXT context, const char *params)
 {
     if ( context->Access == FTP_ACCESS_NOT_LOGGED_IN )
+    {
+        context->Access = FTP_ACCESS_NOT_USERNAME;
         return sendstring(context, error530);
+    }
 
     snprintf(context->FileName, sizeof(context->FileName), "257 \"%s\" is a current directory.\r\n", context->CurrentDir);
     return sendstring(context, context->FileName);
@@ -336,7 +339,10 @@ int ftpPWD(PFTPCONTEXT context, const char *params)
 int ftpTYPE(PFTPCONTEXT context, const char *params)
 {
     if ( context->Access == FTP_ACCESS_NOT_LOGGED_IN )
+    {
+        context->Access = FTP_ACCESS_NOT_USERNAME;
         return sendstring(context, error530);
+    }
 
     if (params == NULL)
         return sendstring(context, error501);
@@ -363,7 +369,10 @@ int ftpPORT(PFTPCONTEXT context, const char *params)
     char		*p = (char *)params;
 
     if ( context->Access == FTP_ACCESS_NOT_LOGGED_IN )
+    {
+        context->Access = FTP_ACCESS_NOT_USERNAME;
         return sendstring(context, error530);
+    }
 
     if ( params == NULL )
         return sendstring(context, error501);
@@ -589,7 +598,10 @@ int ftpLIST(PFTPCONTEXT context, const char *params)
     struct  stat    filestats;
 
     if (context->Access == FTP_ACCESS_NOT_LOGGED_IN)
+    {
+        context->Access = FTP_ACCESS_NOT_USERNAME;
         return sendstring(context, error530);
+    }
     if ((context->WorkerThreadValid == 0) || (context->hFile != -1))
         return sendstring(context, error550_t);
 
@@ -623,7 +635,10 @@ int ftpLIST(PFTPCONTEXT context, const char *params)
 int ftpCDUP(PFTPCONTEXT context, const char *params)
 {
     if ( context->Access == FTP_ACCESS_NOT_LOGGED_IN )
+    {
+        context->Access = FTP_ACCESS_NOT_USERNAME;
         return sendstring(context, error530);
+    }
 
     if ( strcmp(context->CurrentDir, "/") == 0 )
         return sendstring(context, success250);
@@ -639,7 +654,10 @@ int ftpCWD(PFTPCONTEXT context, const char *params)
     struct	stat	filestats;
 
     if ( context->Access == FTP_ACCESS_NOT_LOGGED_IN )
+    {
+        context->Access = FTP_ACCESS_NOT_USERNAME;
         return sendstring(context, error530);
+    }
 
     if ( params == NULL )
         return sendstring(context, error501);
@@ -789,7 +807,10 @@ int ftpRETR(PFTPCONTEXT context, const char *params)
     struct	stat	filestats;
 
     if (context->Access == FTP_ACCESS_NOT_LOGGED_IN)
+    {
+        context->Access = FTP_ACCESS_NOT_USERNAME;
         return sendstring(context, error530);
+    }
     if ( params == NULL )
         return sendstring(context, error501);
     if ((context->WorkerThreadValid == 0) || (context->hFile != -1))
@@ -814,7 +835,10 @@ int ftpRETR(PFTPCONTEXT context, const char *params)
 int ftpABOR(PFTPCONTEXT context, const char *params)
 {
     if ( context->Access == FTP_ACCESS_NOT_LOGGED_IN )
+    {
+        context->Access = FTP_ACCESS_NOT_USERNAME;
         return sendstring(context, error530);
+    }
 
     writelogentry(context, " ABORT command", NULL);
     worker_thread_cleanup(context);
@@ -824,7 +848,10 @@ int ftpABOR(PFTPCONTEXT context, const char *params)
 int ftpDELE(PFTPCONTEXT context, const char *params)
 {
     if ( context->Access == FTP_ACCESS_NOT_LOGGED_IN )
+    {
+        context->Access = FTP_ACCESS_NOT_USERNAME;
         return sendstring(context, error530);
+    }
     if ( context->Access < FTP_ACCESS_FULL )
         return sendstring(context, error550_r);
     if ( params == NULL )
@@ -854,6 +881,7 @@ int pasv(PFTPCONTEXT context)
     {
         if ( context->Access == FTP_ACCESS_NOT_LOGGED_IN )
         {
+            context->Access = FTP_ACCESS_NOT_USERNAME;
             sendstring(context, error530);
             break;
         }
@@ -957,6 +985,8 @@ int ftpPASV(PFTPCONTEXT context, const char *params)
 int ftpPASS(PFTPCONTEXT context, const char *params)
 {
     volatile char temptext[PATH_MAX];
+    if (context->Access == FTP_ACCESS_NOT_USERNAME)
+        return sendstring(context, error530);
 
     if ( params == NULL )
         return sendstring(context, error501);
@@ -1009,7 +1039,10 @@ int ftpPASS(PFTPCONTEXT context, const char *params)
 int ftpREST(PFTPCONTEXT context, const char *params)
 {
     if ( context->Access == FTP_ACCESS_NOT_LOGGED_IN )
+    {
+        context->Access = FTP_ACCESS_NOT_USERNAME;
         return sendstring(context, error530);
+    }
 
     if ( params == NULL )
         return sendstring(context, error501);
@@ -1027,7 +1060,10 @@ int ftpSIZE(PFTPCONTEXT context, const char *params)
     struct stat		filestats;
 
     if ( context->Access == FTP_ACCESS_NOT_LOGGED_IN )
+    {
+        context->Access = FTP_ACCESS_NOT_USERNAME;
         return sendstring(context, error530);
+    }
     if ( params == NULL )
         return sendstring(context, error501);
 
@@ -1048,7 +1084,10 @@ int ftpSIZE(PFTPCONTEXT context, const char *params)
 int ftpMKD(PFTPCONTEXT context, const char *params)
 {
     if ( context->Access == FTP_ACCESS_NOT_LOGGED_IN )
+    {
+        context->Access = FTP_ACCESS_NOT_USERNAME;
         return sendstring(context, error530);
+    }
     if ( context->Access < FTP_ACCESS_CREATENEW )
         return sendstring(context, error550_r);
     if ( params == NULL )
@@ -1069,7 +1108,10 @@ int ftpMKD(PFTPCONTEXT context, const char *params)
 int ftpRMD(PFTPCONTEXT context, const char *params)
 {
     if ( context->Access == FTP_ACCESS_NOT_LOGGED_IN )
+    {
+        context->Access = FTP_ACCESS_NOT_USERNAME;
         return sendstring(context, error530);
+    }
     if ( context->Access < FTP_ACCESS_FULL )
         return sendstring(context, error550_r);
     if ( params == NULL )
@@ -1207,7 +1249,10 @@ int ftpSTOR(PFTPCONTEXT context, const char *params)
     struct  stat    filestats;
 
     if ( context->Access == FTP_ACCESS_NOT_LOGGED_IN )
+    {
+        context->Access = FTP_ACCESS_NOT_USERNAME;
         return sendstring(context, error530);
+    }
     if ( context->Access < FTP_ACCESS_CREATENEW )
         return sendstring(context, error550_r);
     if ( params == NULL )
@@ -1253,7 +1298,10 @@ int parseCHMOD(PFTPCONTEXT context, const char* params)
     mode_t flags = 0;
 
     if ( context->Access == FTP_ACCESS_NOT_LOGGED_IN )
+    {
+        context->Access = FTP_ACCESS_NOT_USERNAME;
         return sendstring(context, error530);
+    }
     if ( context->Access < FTP_ACCESS_FULL )
         return sendstring(context, error550_r);
 
@@ -1309,7 +1357,10 @@ int ftpAPPE(PFTPCONTEXT context, const char *params)
     struct	stat	filestats;
 
     if ( context->Access == FTP_ACCESS_NOT_LOGGED_IN )
+    {
+        context->Access = FTP_ACCESS_NOT_USERNAME;
         return sendstring(context, error530);
+    }
     if ( context->Access < FTP_ACCESS_FULL )
         return sendstring(context, error550_r);
     if ( params == NULL )
@@ -1340,7 +1391,10 @@ int ftpRNFR(PFTPCONTEXT context, const char *params)
     struct stat		filestats;
 
     if ( context->Access == FTP_ACCESS_NOT_LOGGED_IN )
+    {
+        context->Access = FTP_ACCESS_NOT_USERNAME;
         return sendstring(context, error530);
+    }
     if ( context->Access < FTP_ACCESS_FULL )
         return sendstring(context, error550_r);
     if ( params == NULL )
@@ -1362,7 +1416,10 @@ int ftpRNFR(PFTPCONTEXT context, const char *params)
 int ftpRNTO(PFTPCONTEXT context, const char *params)
 {
     if ( context->Access == FTP_ACCESS_NOT_LOGGED_IN )
+    {
+        context->Access = FTP_ACCESS_NOT_USERNAME;
         return sendstring(context, error530);
+    }
     if ( context->Access < FTP_ACCESS_FULL )
         return sendstring(context, error550_r);
     if ( params == NULL )
@@ -1421,7 +1478,10 @@ int ftpPBSZ (PFTPCONTEXT context, const char *params)
 int ftpPROT (PFTPCONTEXT context, const char *params)
 {
     if ( context->Access == FTP_ACCESS_NOT_LOGGED_IN )
+    {
+        context->Access = FTP_ACCESS_NOT_USERNAME;
         return sendstring(context, error530);
+    }
 
     if ( params == NULL )
         return sendstring(context, error501);
@@ -1506,7 +1566,10 @@ int ftpMLSD(PFTPCONTEXT context, const char *params)
     struct  stat    filestats;
 
     if (context->Access == FTP_ACCESS_NOT_LOGGED_IN)
+    {
+        context->Access = FTP_ACCESS_NOT_USERNAME;
         return sendstring(context, error530);
+    }
     if ((context->WorkerThreadValid == 0) || (context->hFile != -1))
         return sendstring(context, error550_t);
 

--- a/src/ftpserv.h
+++ b/src/ftpserv.h
@@ -78,6 +78,7 @@ typedef struct _FTP_CONFIG {
  * FULL = "admin" in config. All access features enabled.
  */
 
+#define FTP_ACCESS_NOT_USERNAME    -1
 #define FTP_ACCESS_NOT_LOGGED_IN    0
 #define FTP_ACCESS_READONLY         1
 #define FTP_ACCESS_CREATENEW        2
@@ -212,7 +213,7 @@ extern const char success214[];
 #define error501       "501 Syntax error in parameters or arguments.\r\n"
 #define error503       "503 Invalid sequence of commands (AUTH TLS required prior to authentication).\r\n"
 #define error504       "504 Command not implemented for that parameter.\r\n"
-#define error530       "530 Please login with USER and PASS.\r\n"
+#define error530       "530 Please login with USER and PASS: use USER immediately followed by PASS.\r\n"
 #define error530_b     "530 This account is disabled.\r\n"
 #define error530_r     "530 Invalid user name or password.\r\n"
 #define error550       "550 File or directory unavailable.\r\n"


### PR DESCRIPTION
- Fix: #39 
- To address this issue, we:

    1. Introduce a new state "FTP_ACCESS_NOT_USERNAME" of context_Access in `./src/ftpserv.h`; 
    2. Update the context_Access state whenever other commands are issued between USER and PASS commands (`./src/ftpserv.c`); 
    3. Add an additional check within the ftpPASS function to verify whether USER immediately followed by PASS (`./src/ftpserv.c`).

If there are aspects that need adjustment, I would be more than happy to assist.

Thank you for your attention, and I look forward to your response.