### PR TITLE
(Fix_40) Inconsistency Between LightFTP and RFC 959: Violation of server marker Requirement in Argument Field of REST command

### DIFF
--- a/src/ftpserv.c
+++ b/src/ftpserv.c
@@ -1013,7 +1013,15 @@ int ftpREST(PFTPCONTEXT context, const char *params)
 
     if ( params == NULL )
         return sendstring(context, error501);
-
+    
+    for (const char *p = params; *p != '\0'; p++)
+    {
+        if (!isprint((unsigned char)*p) || *p < 33 || *p > 126)
+        {
+            return sendstring(context, error501); 
+        }
+    }
+    
     context->RestPoint = strtoull(params, NULL, 10);
     snprintf(context->FileName, sizeof(context->FileName),
             "350 REST supported. Ready to resume at byte offset %llu\r\n",


### PR DESCRIPTION
- Fix: #40 
- To address this issue, we added a check for the parameter value range in the `ftpREST` function and returned a warning when an invalid value is encountered.