### PR TITLE
(Fix_38) Inconsistency Between LightFTP and RFC 959: Violation of Telnet String Requirement in Argument Field

### DIFF
--- a/src/ftpserv.c
+++ b/src/ftpserv.c
@@ -294,6 +294,10 @@ int ftpUSER(PFTPCONTEXT context, const char *params)
     if ( params == NULL )
         return sendstring(context, error501);
 
+    if (strchr(params, '\r') != NULL || strchr(params, '\n') != NULL) {
+        return sendstring(context, error501);
+    }
+
     context->Access = FTP_ACCESS_NOT_LOGGED_IN;
 
     writelogentry(context, " USER: ", (char *)params);
@@ -340,6 +344,10 @@ int ftpTYPE(PFTPCONTEXT context, const char *params)
 
     if (params == NULL)
         return sendstring(context, error501);
+    
+    if (strchr(params, '\r') != NULL || strchr(params, '\n') != NULL) {
+        return sendstring(context, error501);
+    }
 
     switch (*params)
     {
@@ -960,6 +968,10 @@ int ftpPASS(PFTPCONTEXT context, const char *params)
 
     if ( params == NULL )
         return sendstring(context, error501);
+    
+    if (strchr(params, '\r') != NULL || strchr(params, '\n') != NULL) {
+        return sendstring(context, error501);
+    }
 
     memset(temptext, 0, sizeof(temptext));
 


### PR DESCRIPTION
- Fix: #38 
- To address this issue, we implemented checks for the argument field in the relevant functions to handle and report violations of the Telnet String Requirement. (`ftpUSER`, `ftpTYPE`, and `ftpPASS`)