### PR TITLE
(Fix_47) Inconsistency Between LightFTP and RFC 959: Violation of IP and Port Requirements in Argument Field of PORT command.

### DIFF
--- a/src/ftpserv.c
+++ b/src/ftpserv.c
@@ -377,6 +377,11 @@ ssize_t ftpPORT(pftp_context context, const char *params)
         return sendstring(context, error501);
 
     for (c = 0; c < 4; ++c) {
+        unsigned long num = strtoul(p, NULL, 10);
+        if (num < 0 || num > 255){
+			return sendstring(context, error501); // Invalid range check
+		}
+
         data_ipv4 += ((in_addr_t)strtoul(p, NULL, 10)) << c*8;
         while ( (*p >= '0') && (*p <= '9') )
             ++p;
@@ -386,6 +391,10 @@ ssize_t ftpPORT(pftp_context context, const char *params)
     }
 
     for (c = 0; c < 2; ++c) {
+        unsigned long num = strtoul(p, NULL, 10);
+        if (num < 0 || num > 255){
+			return sendstring(context, error501); // Invalid range check
+		}
         data_port += ((in_addr_t)strtoul(p, NULL, 10)) << c*8;
         while ( (*p >= '0') && (*p <= '9') )
             ++p;


### PR DESCRIPTION
- Fix: #47 
- To address this issue, we added checks for the parameter value range in the ftpPORT function and returned a warning when an invalid value is encountered.