### PR TITLE
(Fix 49) Inconsistency Between LightFTP and RFC 959: Violation of the response code for unimplemented arguments in the TYPE command.

### DIFF
--- a/src/ftpserv.c
+++ b/src/ftpserv.c
@@ -358,6 +358,11 @@ ssize_t ftpTYPE(pftp_context context, const char *params)
     case 'I':
     case 'i':
         return sendstring(context, success200_2);
+    
+    case 'L':
+        return sendstring(context, error504);
+    case 'E':
+        return sendstring(context, error504);
 
     default:
         return sendstring(context, error501);


### PR DESCRIPTION
- Fix #49 
- To address this issue, we added expected warning logic for the valid but unimplemented parameters in the ftpTYPE function.