### PR TITLE
(Fix_51_new) Inconsistency Between LightFTP and RFC 959: Violation of the response code for unimplemented commands (MODE and STRU).

### DIFF
--- a/src/ftpserv.c
+++ b/src/ftpserv.c
@@ -22,7 +22,8 @@ static const ftproutine_entry ftpprocs[MAX_CMDS] = {
         {"MKD",  ftpMKD }, {"RMD",  ftpRMD }, {"STOR", ftpSTOR}, {"SYST", ftpSYST},
         {"FEAT", ftpFEAT}, {"APPE", ftpAPPE}, {"RNFR", ftpRNFR}, {"RNTO", ftpRNTO},
         {"OPTS", ftpOPTS}, {"MLSD", ftpMLSD}, {"AUTH", ftpAUTH}, {"PBSZ", ftpPBSZ},
-        {"PROT", ftpPROT}, {"EPSV", ftpEPSV}, {"HELP", ftpHELP}, {"SITE", ftpSITE}
+        {"PROT", ftpPROT}, {"EPSV", ftpEPSV}, {"HELP", ftpHELP}, {"SITE", ftpSITE},
+        {"MODE", ftpMODE}, {"STRU", ftpSTRU}
 };
 
 void *mlsd_thread(pthcontext tctx);
@@ -1549,6 +1550,16 @@ ssize_t ftpMLSD(pftp_context context, const char *params)
     }
 
     return sendstring(context, error550);
+}
+
+ssize_t ftpMODE(pftp_context context, const char *params)
+{
+    return sendstring(context, error502);
+}
+
+ssize_t ftpSTRU(pftp_context context, const char *params)
+{
+    return sendstring(context, error502);
 }
 
 int recvcmd(pftp_context context, char *buffer, size_t buffer_size)

--- a/src/inc/ftpserv.h
+++ b/src/inc/ftpserv.h
@@ -163,7 +163,7 @@ extern gnutls_priority_t                    priority_cache;
 extern gnutls_datum_t                       session_keys_storage;
 
 #define FTP_COMMAND(cmdname)    ssize_t cmdname(pftp_context context, const char* params)
-#define MAX_CMDS                32
+#define MAX_CMDS                34
 extern const char               shortmonths[12][4];
 
 FTP_COMMAND(ftpUSER);
@@ -198,6 +198,8 @@ FTP_COMMAND(ftpPROT);
 FTP_COMMAND(ftpEPSV);
 FTP_COMMAND(ftpHELP);
 FTP_COMMAND(ftpSITE);
+FTP_COMMAND(ftpMODE);
+FTP_COMMAND(ftpSTRU);
 
 #define success200     "200 Command okay.\r\n"
 #define success200_1   "200 Type set to A.\r\n"
@@ -221,6 +223,7 @@ extern const char success214[];
 #define error500       "500 Syntax error, command unrecognized.\r\n"
 #define error500_auth  "500 AUTH unsuccessful.\r\n"
 #define error501       "501 Syntax error in parameters or arguments.\r\n"
+#define error502       "502 Command not implemented.\r\n";
 #define error503       "503 Invalid sequence of commands (AUTH TLS required prior to authentication).\r\n"
 #define error504       "504 Command not implemented for that parameter.\r\n"
 #define error530       "530 Please login with USER and PASS.\r\n"


### PR DESCRIPTION
- Fix #51 
- To address this issue, we added expected warning logic for the valid but unimplemented commands (MODE and STRU).