### PR TITLE
(RFC-compliance: Issue 49) Enhancing RFC Compliance Regarding Response Codes for Unimplemented Arguments in TYPE command.

### DIFF
--- a/src/ftpserv.c
+++ b/src/ftpserv.c
@@ -364,6 +364,11 @@ int ftpTYPE(PFTPCONTEXT context, const char *params)
     case 'I':
     case 'i':
         return sendstring(context, success200_2);
+    
+    case 'L':
+        return sendstring(context, error504);
+    case 'E':
+        return sendstring(context, error504);
 
     default:
         return sendstring(context, error501);


### PR DESCRIPTION
We respectfully submit this pull request in order to improve the consistency between LightFTP and the RFC.

- **Branch to Merge**: [RFC-compliance](https://github.com/hfiref0x/LightFTP/tree/RFC-compliance)
- Issue to Enhance/Fix: https://github.com/hfiref0x/LightFTP/issues/49
- To address this issue, we added expected warning logic for the valid but unimplemented parameters in the ftpTYPE function.

If there are aspects that need adjustment, we would be more than happy to assist.

Thank you for your time, and we look forward to your response : )